### PR TITLE
Fix animationend event wrong target

### DIFF
--- a/px-alert-message.html
+++ b/px-alert-message.html
@@ -216,13 +216,13 @@ Custom property | Description
      }
   },
   attached: function() {
-    this.listen(this, 'animationend', '_hide');
+    this.listen(this.$.alert, 'animationend', '_hide');
     this.listen(this, 'app-localize-resources-loaded', '_checkMessageLength');
     this._checkMessageLength();
     this.listen(this.$.showMoreButton, 'tap', '_toggleExpansion');
   },
   detached: function() {
-    this.unlisten(this, 'animationend', '_hide');
+    this.unlisten(this.$.alert, 'animationend', '_hide');
     this.unlisten(this, 'app-localize-resources-loaded', '_checkMessageLength');
     this.unlisten(this.$.showMoreButton, 'tap', '_toggleExpansion');
   },


### PR DESCRIPTION
I have a component using px-alter-message. In the demo page of my component, px-alert-message works as expected. When I integrate my component in my app, px-alert-message never close when I click close button.
In px-alert-message.html, in function _hide, event.target points on div#alert when everything works well, and in my app context it points on px-alert-message itself and _hide fails due to class fade-out not found.

I didn't find how to reproduce out of my app context, and I don't know exactly what is going wrong. I open this pull request because this fixes the issue, and _hide function is only made to watch div#alert so I think listening event directly on it instead of its parent is better.

